### PR TITLE
Remove unneeded info call.

### DIFF
--- a/robolearnr/__init__.py
+++ b/robolearnr/__init__.py
@@ -23,7 +23,6 @@ class Robolearn:
 
     def reset(self):
         self.__server_rpc('reset')
-        self.__server_rpc('info')
 
     def before_obstacle(self):
         return self.info['before_obstacle']


### PR DESCRIPTION
Since __server_rpc assignes every response to info and "reset" actually returns the info, the extra "info" call is unnecessary.